### PR TITLE
feat: Enable auto-scroll when dragging headers

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,7 @@
 # TODO
 ## Features
 - [x] Add profile import from ModHeader. Look in the "__import_examples__" folder, and then in the respective sub-folder for "ModHeader". There's an example of what the exported file from that service looks like.
+- [x] Implement scrolling when dragging a header to the top or bottom so you can move it around more easily.
 - [ ] i18n for all strings
 - [ ] Implement filter functionality, allowing for enabling or disabling a profile depending on the url you're visiting. Preferably easy methods, like "starts with", "host equals" etc.
 - [ ] Implement adding response headers, the same way we add request headers.

--- a/src/components/HeaderList.vue
+++ b/src/components/HeaderList.vue
@@ -96,6 +96,7 @@ onMounted(() => {
     swapy.value = createSwapy(container.value, {
       manualSwap: true,
       animation: 'dynamic',
+      autoScrollOnDrag: true,
     })
 
     // onSwap fires during drag - update slotItemMap for visual feedback


### PR DESCRIPTION
Enable Swapy's built-in autoScrollOnDrag option so the header list automatically scrolls when dragging a header near the top or bottom edge of the viewport. This makes it easier to reorder headers in long lists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)