### PR TITLE
Move header tabs below status bar

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -149,17 +149,7 @@ function handleImport() {
       />
 
       <!-- Headers Content -->
-      <div class="flex-1 flex flex-col min-h-0">
-        <div class="px-3 py-2 border-b border-border bg-background">
-          <Tabs v-model="activeHeaderType" class="w-full">
-            <TabsList class="w-full">
-              <TabsTrigger value="request">Request</TabsTrigger>
-              <TabsTrigger value="response">Response</TabsTrigger>
-            </TabsList>
-          </Tabs>
-        </div>
-
-        <div class="flex-1 overflow-y-auto">
+      <div class="flex-1 overflow-y-auto min-h-0">
         <HeaderList
           :title="activeTitle"
           :type="activeHeaderType"
@@ -172,8 +162,16 @@ function handleImport() {
           @duplicate="handleDuplicateHeader"
           @clear="handleClearHeaders"
           @reorder="handleReorderHeaders"
-        />
-        </div>
+        >
+          <template #tabs>
+            <Tabs v-model="activeHeaderType" class="w-full">
+              <TabsList class="w-full">
+                <TabsTrigger value="request">Request</TabsTrigger>
+                <TabsTrigger value="response">Response</TabsTrigger>
+              </TabsList>
+            </Tabs>
+          </template>
+        </HeaderList>
       </div>
     </div>
   </div>

--- a/src/__tests__/components/App.test.ts
+++ b/src/__tests__/components/App.test.ts
@@ -34,6 +34,7 @@ const HeaderListStub = {
       :data-type="type"
       :data-count="headers.length"
     >
+      <slot name="tabs" />
       <button data-test="list-add" @click="$emit('add')">ADD</button>
       <button data-test="list-clear" @click="$emit('clear')">CLEAR</button>
     </div>

--- a/src/components/HeaderList.vue
+++ b/src/components/HeaderList.vue
@@ -146,6 +146,11 @@ onUnmounted(() => {
       </div>
     </div>
 
+    <!-- Optional controls (e.g., Request/Response tabs) -->
+    <div v-if="$slots.tabs" class="px-3 py-2 bg-background border-b border-border/50">
+      <slot name="tabs" />
+    </div>
+
     <!-- Headers List -->
     <div ref="container" class="flex flex-col bg-background">
       <div


### PR DESCRIPTION
Moves the Request/Response tab switcher below the colored header status bar ("Request headers" / "Response headers") so the bar stays at the top and only changes its status text.

### What changed
- `HeaderList` now exposes an optional `tabs` slot rendered right below its colored header bar.
- `App.vue` renders the Request/Response tabs via that slot instead of in a separate bar above the list.

### Validation
- `bun run test:run`
- `bun run build`