### PR TITLE
feat: advanced profile color picker + contrast-safe profile labels

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,7 @@
         "@vueuse/core": "^14.2.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "culori": "^4.0.2",
         "lucide-vue-next": "^0.563.0",
         "pinia": "^3.0.4",
         "reka-ui": "^2.8.0",
@@ -22,6 +23,7 @@
       "devDependencies": {
         "@playwright/test": "^1.58.1",
         "@types/chrome": "^0.1.36",
+        "@types/culori": "^4.0.1",
         "@types/node": "^24.10.1",
         "@types/uuid": "^10.0.0",
         "@vitejs/plugin-vue": "^6.0.1",
@@ -350,6 +352,8 @@
 
     "@types/chrome": ["@types/chrome@0.1.36", "", { "dependencies": { "@types/filesystem": "*", "@types/har-format": "*" } }, "sha512-BvHbuyGttYXnGt5Gpwa4769KIinKHY1iLjlAPrrMBS2GI9m/XNMPtdsq0NgQalyuUdxvlMN/0OyGw0shFVIoUQ=="],
 
+    "@types/culori": ["@types/culori@4.0.1", "", {}, "sha512-43M51r/22CjhbOXyGT361GZ9vncSVQ39u62x5eJdBQFviI8zWp2X5jzqg7k4M6PVgDQAClpy2bUe2dtwEgEDVQ=="],
+
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
@@ -561,6 +565,8 @@
     "cssstyle": ["cssstyle@5.3.7", "", { "dependencies": { "@asamuzakjp/css-color": "^4.1.1", "@csstools/css-syntax-patches-for-csstree": "^1.0.21", "css-tree": "^3.1.0", "lru-cache": "^11.2.4" } }, "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ=="],
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
+    "culori": ["culori@4.0.2", "", {}, "sha512-1+BhOB8ahCn4O0cep0Sh2l9KCOfOdY+BXJnKMHFFzDEouSr/el18QwXEMRlOj9UY5nCeA8UN3a/82rUWRBeyBw=="],
 
     "data-urls": ["data-urls@6.0.1", "", { "dependencies": { "whatwg-mimetype": "^5.0.0", "whatwg-url": "^15.1.0" } }, "sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ=="],
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@vueuse/core": "^14.2.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "culori": "^4.0.2",
     "lucide-vue-next": "^0.563.0",
     "pinia": "^3.0.4",
     "reka-ui": "^2.8.0",
@@ -31,6 +32,7 @@
   "devDependencies": {
     "@playwright/test": "^1.58.1",
     "@types/chrome": "^0.1.36",
+    "@types/culori": "^4.0.1",
     "@types/node": "^24.10.1",
     "@types/uuid": "^10.0.0",
     "@vitejs/plugin-vue": "^6.0.1",

--- a/src/App.vue
+++ b/src/App.vue
@@ -166,6 +166,12 @@ function handleDuplicateProfile() {
   }
 }
 
+function handleUpdateProfileColor(color: string) {
+  if (store.activeProfileId) {
+    store.updateProfile(store.activeProfileId, { color })
+  }
+}
+
 // Import/Export
 function downloadExport(data: string, filename: string) {
   const blob = new Blob([data], { type: 'application/json' })
@@ -238,6 +244,7 @@ function handleImport() {
         @redo="store.redo"
         @export="handleExportProfile"
         @rename="handleRenameProfile"
+        @update-color="handleUpdateProfileColor"
       />
 
       <div class="flex-1 flex flex-col min-h-0">

--- a/src/__tests__/color.test.ts
+++ b/src/__tests__/color.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest'
+import {
+  getReadableTextColor,
+  parseColorInputToRgb,
+  parseColorInputToHex,
+} from '@/lib/color'
+
+function toLinear(value: number): number {
+  const normalized = value / 255
+  return normalized <= 0.04045
+    ? normalized / 12.92
+    : ((normalized + 0.055) / 1.055) ** 2.4
+}
+
+function luminance(hexColor: string): number {
+  const rgb = parseColorInputToRgb(hexColor)
+  if (!rgb) return 0
+  return 0.2126 * toLinear(rgb.r) + 0.7152 * toLinear(rgb.g) + 0.0722 * toLinear(rgb.b)
+}
+
+function contrastRatio(foreground: string, background: string): number {
+  const l1 = luminance(foreground)
+  const l2 = luminance(background)
+  const light = Math.max(l1, l2)
+  const dark = Math.min(l1, l2)
+  return (light + 0.05) / (dark + 0.05)
+}
+
+describe('color utils', () => {
+  it('parses hex and rgb inputs', () => {
+    expect(parseColorInputToHex('#ff00aa')).toBe('#ff00aa')
+    expect(parseColorInputToHex('rgb(255, 0, 170)')).toBe('#ff00aa')
+  })
+
+  it('parses oklch input', () => {
+    const parsed = parseColorInputToHex('oklch(62% 0.22 328)')
+    expect(parsed).toMatch(/^#[0-9a-f]{6}$/)
+  })
+
+  it('returns high-contrast readable text across bright, dark, and mid backgrounds', () => {
+    const backgrounds = ['#ffffff', '#000000', '#4c3f8f', '#93c5fd', '#10b981']
+    for (const background of backgrounds) {
+      const text = getReadableTextColor(background)
+      expect(text).toMatch(/^#[0-9a-f]{6}$/)
+      expect(contrastRatio(text, background)).toBeGreaterThanOrEqual(4.5)
+    }
+  })
+
+  it('keeps a near-white text color on darker blue surfaces', () => {
+    const text = getReadableTextColor('#003b72')
+    expect(text).toMatch(/^#[0-9a-f]{6}$/)
+
+    const rgb = parseColorInputToRgb(text)
+    expect(rgb).toBeTruthy()
+    expect((rgb?.r ?? 0)).toBeGreaterThanOrEqual(240)
+    expect((rgb?.g ?? 0)).toBeGreaterThanOrEqual(240)
+    expect((rgb?.b ?? 0)).toBeGreaterThanOrEqual(240)
+    expect(contrastRatio(text, '#003b72')).toBeGreaterThanOrEqual(4.5)
+  })
+})

--- a/src/__tests__/components/ProfileHeader.test.ts
+++ b/src/__tests__/components/ProfileHeader.test.ts
@@ -3,25 +3,17 @@ import { mount } from '@vue/test-utils'
 import ProfileHeader from '@/components/ProfileHeader.vue'
 import type { Profile } from '@/types'
 
-// Mock lucide-vue-next icons
 vi.mock('lucide-vue-next', () => ({
   Undo2: { template: '<span>Undo2</span>' },
   Redo2: { template: '<span>Redo2</span>' },
-  Plus: { template: '<span>Plus</span>' },
   Download: { template: '<span>Download</span>' },
-  Upload: { template: '<span>Upload</span>' },
-  MoreVertical: { template: '<span>MoreVertical</span>' },
-  Copy: { template: '<span>Copy</span>' },
-  Trash2: { template: '<span>Trash2</span>' },
-  Moon: { template: '<span>Moon</span>' },
-  Sun: { template: '<span>Sun</span>' },
-  Contrast: { template: '<span>Contrast</span>' },
+  Pipette: { template: '<span>Pipette</span>' },
 }))
 
 describe('ProfileHeader', () => {
   const createProfile = (overrides: Partial<Profile> = {}): Profile => ({
-    id: 'test-profile-id',
-    name: 'Test Profile',
+    id: 'profile-1',
+    name: 'Profile 1',
     color: '#7c3aed',
     headers: [],
     urlFilters: [],
@@ -30,217 +22,150 @@ describe('ProfileHeader', () => {
     ...overrides,
   })
 
-  const defaultProps = {
-    profile: createProfile(),
-    profileIndex: 0,
-    canUndo: false,
-    canRedo: false,
-    darkModePreference: 'system' as const,
-    languagePreference: 'auto' as const,
-  }
-
-  const mountComponent = (props = {}) => {
+  const mountComponent = (props: Partial<{
+    profile: Profile | null
+    profileIndex: number
+    canUndo: boolean
+    canRedo: boolean
+  }> = {}) => {
     return mount(ProfileHeader, {
-      props: { ...defaultProps, ...props },
+      props: {
+        profile: createProfile(),
+        profileIndex: 0,
+        canUndo: false,
+        canRedo: false,
+        ...props,
+      },
       global: {
         stubs: {
           Button: {
             template: '<button :disabled="disabled" @click="$emit(\'click\')"><slot /></button>',
-            props: ['disabled', 'variant', 'size', 'class'],
+            props: ['disabled'],
           },
           Input: {
-            template: '<input :value="modelValue" @blur="$emit(\'blur\')" @keyup="handleKeyup" @input="$emit(\'update:modelValue\', $event.target.value)" />',
+            template: `
+              <input
+                v-bind="$attrs"
+                :value="modelValue"
+                @blur="$emit('blur')"
+                @input="$emit('update:modelValue', $event.target.value)"
+                @keyup="onKeyup"
+              >
+            `,
             props: ['modelValue'],
             methods: {
-              handleKeyup(e: KeyboardEvent) {
-                if (e.key === 'Enter') this.$emit('keyup.enter')
-                if (e.key === 'Escape') this.$emit('keyup.escape')
+              onKeyup(event: KeyboardEvent) {
+                if (event.key === 'Enter') this.$emit('keyup.enter')
+                if (event.key === 'Escape') this.$emit('keyup.escape')
               },
             },
           },
+          Popover: { template: '<div><slot /></div>' },
+          PopoverTrigger: { template: '<div><slot /></div>' },
+          PopoverContent: { template: '<div><slot /></div>' },
           Tooltip: { template: '<div><slot /></div>' },
           TooltipContent: { template: '<div><slot /></div>' },
           TooltipProvider: { template: '<div><slot /></div>' },
           TooltipTrigger: { template: '<div><slot /></div>' },
-          DropdownMenu: { template: '<div><slot /></div>' },
-          DropdownMenuTrigger: { template: '<div><slot /></div>' },
-          DropdownMenuContent: { template: '<div><slot /></div>' },
-          DropdownMenuItem: {
-            template: '<div @click="$emit(\'select\')"><slot /></div>',
-          },
-          DropdownMenuSeparator: { template: '<hr />' },
-          DropdownMenuLabel: { template: '<div><slot /></div>' },
-          Select: { template: '<div><slot /></div>' },
-          SelectTrigger: { template: '<div><slot /></div>' },
-          SelectValue: { template: '<div><slot /></div>', props: ['placeholder'] },
-          SelectContent: { template: '<div><slot /></div>' },
-          SelectItem: { template: '<div><slot /></div>', props: ['value'] },
-          AlertDialog: { template: '<div v-if="open"><slot /></div>', props: ['open'] },
-          AlertDialogContent: { template: '<div><slot /></div>' },
-          AlertDialogHeader: { template: '<div><slot /></div>' },
-          AlertDialogTitle: { template: '<div><slot /></div>' },
-          AlertDialogDescription: { template: '<div><slot /></div>' },
-          AlertDialogFooter: { template: '<div><slot /></div>' },
-          AlertDialogCancel: { template: '<button @click="$emit(\'click\')">Cancel</button>' },
-          AlertDialogAction: { template: '<button @click="$emit(\'click\')"><slot /></button>' },
         },
       },
     })
   }
 
-  describe('rendering', () => {
-    it('displays profile name', () => {
-      const wrapper = mountComponent({
-        profile: createProfile({ name: 'My Profile' }),
-      })
-
-      expect(wrapper.text()).toContain('My Profile')
+  it('renders profile name and index badge', () => {
+    const wrapper = mountComponent({
+      profile: createProfile({ name: 'My Profile' }),
+      profileIndex: 2,
     })
 
-    it('displays profile index + 1 as badge', () => {
-      const wrapper = mountComponent({ profileIndex: 2 })
-
-      expect(wrapper.text()).toContain('3')
-    })
-
-    it('renders theme toggle group with all options', () => {
-      const wrapper = mountComponent()
-
-      expect(wrapper.text()).toContain('System')
-      expect(wrapper.text()).toContain('Light')
-      expect(wrapper.text()).toContain('Dark')
-    })
-
-    it('applies profile color as background', () => {
-      const wrapper = mountComponent({
-        profile: createProfile({ color: '#ff0000' }),
-      })
-
-      const header = wrapper.find('[style]')
-      expect(header.attributes('style')).toContain('background-color: rgb(255, 0, 0)')
-    })
+    expect(wrapper.text()).toContain('My Profile')
+    expect(wrapper.text()).toContain('3')
   })
 
-  describe('button states', () => {
-    it('disables undo button when canUndo is false', () => {
-      const wrapper = mountComponent({ canUndo: false })
+  it('emits undo, redo and export actions', async () => {
+    const wrapper = mountComponent({ canUndo: true, canRedo: true })
+    const buttons = wrapper.findAll('button')
 
-      const buttons = wrapper.findAll('button')
-      const undoButton = buttons.find(b => b.text().includes('Undo2'))
-      expect(undoButton?.attributes('disabled')).toBeDefined()
-    })
+    const undoButton = buttons.find(b => b.text().includes('Undo2'))
+    const redoButton = buttons.find(b => b.text().includes('Redo2'))
+    const exportButton = buttons.find(b => b.text().includes('Download'))
 
-    it('enables undo button when canUndo is true', () => {
-      const wrapper = mountComponent({ canUndo: true })
+    await undoButton?.trigger('click')
+    await redoButton?.trigger('click')
+    await exportButton?.trigger('click')
 
-      const buttons = wrapper.findAll('button')
-      const undoButton = buttons.find(b => b.text().includes('Undo2'))
-      expect(undoButton?.attributes('disabled')).toBeUndefined()
-    })
-
-    it('disables redo button when canRedo is false', () => {
-      const wrapper = mountComponent({ canRedo: false })
-
-      const buttons = wrapper.findAll('button')
-      const redoButton = buttons.find(b => b.text().includes('Redo2'))
-      expect(redoButton?.attributes('disabled')).toBeDefined()
-    })
-
-    it('enables redo button when canRedo is true', () => {
-      const wrapper = mountComponent({ canRedo: true })
-
-      const buttons = wrapper.findAll('button')
-      const redoButton = buttons.find(b => b.text().includes('Redo2'))
-      expect(redoButton?.attributes('disabled')).toBeUndefined()
-    })
+    expect(wrapper.emitted('undo')).toBeTruthy()
+    expect(wrapper.emitted('redo')).toBeTruthy()
+    expect(wrapper.emitted('export')).toBeTruthy()
   })
 
-  describe('events', () => {
-    it('emits undo when undo button is clicked', async () => {
-      const wrapper = mountComponent({ canUndo: true })
-
-      const buttons = wrapper.findAll('button')
-      const undoButton = buttons.find(b => b.text().includes('Undo2'))
-      await undoButton?.trigger('click')
-
-      expect(wrapper.emitted('undo')).toBeTruthy()
+  it('emits rename when editing profile name and pressing enter', async () => {
+    const wrapper = mountComponent({
+      profile: createProfile({ name: 'Initial Name' }),
     })
 
-    it('emits redo when redo button is clicked', async () => {
-      const wrapper = mountComponent({ canRedo: true })
+    await wrapper.find('.flex-1.font-medium.cursor-pointer').trigger('dblclick')
 
-      const buttons = wrapper.findAll('button')
-      const redoButton = buttons.find(b => b.text().includes('Redo2'))
-      await redoButton?.trigger('click')
+    const textInput = wrapper.get('[data-testid="profile-name-input"]')
+    await textInput.setValue('Renamed Profile')
+    await textInput.trigger('keyup', { key: 'Enter' })
 
-      expect(wrapper.emitted('redo')).toBeTruthy()
-    })
-
-    it('emits addHeader when plus button is clicked', async () => {
-      const wrapper = mountComponent()
-
-      const buttons = wrapper.findAll('button')
-      const addButton = buttons.find(b => b.text().includes('Plus'))
-      await addButton?.trigger('click')
-
-      expect(wrapper.emitted('addHeader')).toBeTruthy()
-    })
-
-    it('emits export when download button is clicked', async () => {
-      const wrapper = mountComponent()
-
-      const buttons = wrapper.findAll('button')
-      const exportButton = buttons.find(b => b.text().includes('Download'))
-      await exportButton?.trigger('click')
-
-      expect(wrapper.emitted('export')).toBeTruthy()
-    })
-
-    it('renders import menu item', async () => {
-      const wrapper = mountComponent()
-      // Verify the menu item exists in the rendered output
-      expect(wrapper.html()).toContain('Import')
-    })
-
-    it('renders duplicate menu item', async () => {
-      const wrapper = mountComponent()
-      // Verify the menu item exists in the rendered output
-      expect(wrapper.html()).toContain('Duplicate')
-    })
-
-    it('renders theme toggle buttons in dropdown menu', async () => {
-      const wrapper = mountComponent()
-      expect(wrapper.text()).toContain('System')
-      expect(wrapper.text()).toContain('Light')
-      expect(wrapper.text()).toContain('Dark')
-    })
-
-    it('renders delete menu item', async () => {
-      const wrapper = mountComponent()
-      // Verify the menu item exists in the rendered output
-      expect(wrapper.html()).toContain('Delete profile')
-    })
+    const renameEvents = wrapper.emitted('rename')
+    expect(renameEvents).toBeTruthy()
+    expect(renameEvents?.[0]).toEqual(['Renamed Profile'])
   })
 
-  describe('inline editing', () => {
-    it('shows input when profile name is double-clicked', async () => {
-      const wrapper = mountComponent({
-        profile: createProfile({ name: 'Test Profile' }),
-      })
-
-      const nameElement = wrapper.find('.cursor-pointer')
-      await nameElement.trigger('dblclick')
-
-      const input = wrapper.find('input')
-      expect(input.exists()).toBe(true)
+  it('emits updateColor when hue slider changes', async () => {
+    const wrapper = mountComponent({
+      profile: createProfile({ color: '#7c3aed' }),
     })
+
+    const hueSlider = wrapper.get('[data-testid="profile-color-hue-slider"]')
+    await hueSlider.setValue('120')
+
+    const events = wrapper.emitted('updateColor')
+    expect(events).toBeTruthy()
+    const emittedColor = events?.[0]?.[0]
+    expect(typeof emittedColor).toBe('string')
+    expect(emittedColor).toMatch(/^#[0-9a-f]{6}$/)
+    expect(emittedColor).not.toBe('#7c3aed')
   })
 
-  describe('null profile handling', () => {
-    it('shows default text when profile is null', () => {
-      const wrapper = mountComponent({ profile: null })
-
-      expect(wrapper.text()).toContain('Profile')
+  it('emits updateColor when saturation slider changes', async () => {
+    const wrapper = mountComponent({
+      profile: createProfile({ color: '#7c3aed' }),
     })
+
+    const saturationSlider = wrapper.get('[data-testid="profile-color-saturation-slider"]')
+    await saturationSlider.setValue('30')
+
+    const events = wrapper.emitted('updateColor')
+    expect(events).toBeTruthy()
+    const emittedColor = events?.[0]?.[0]
+    expect(typeof emittedColor).toBe('string')
+    expect(emittedColor).toMatch(/^#[0-9a-f]{6}$/)
+  })
+
+  it('accepts rgb value in color input', async () => {
+    const wrapper = mountComponent({
+      profile: createProfile({ color: '#7c3aed' }),
+    })
+
+    const colorValueInput = wrapper.get('[data-testid="profile-color-value-input"]')
+    await colorValueInput.setValue('rgb(255, 0, 153)')
+    await colorValueInput.trigger('keyup', { key: 'Enter' })
+
+    const events = wrapper.emitted('updateColor')
+    expect(events).toBeTruthy()
+    const lastEvent = events?.[events.length - 1]
+    expect(lastEvent?.[0]).toBe('#ff0099')
+  })
+
+  it('disables color trigger when profile is null', () => {
+    const wrapper = mountComponent({ profile: null })
+    const trigger = wrapper.get('[data-testid="profile-color-trigger"]')
+
+    expect(trigger.attributes('disabled')).toBeDefined()
+    expect(wrapper.text()).toContain('Profile')
   })
 })

--- a/src/__tests__/components/ProfileSidebar.test.ts
+++ b/src/__tests__/components/ProfileSidebar.test.ts
@@ -1,11 +1,19 @@
 import { describe, it, expect, vi } from 'vitest'
 import { mount } from '@vue/test-utils'
 import ProfileSidebar from '@/components/ProfileSidebar.vue'
-import type { Profile } from '@/types'
+import type { DarkModePreference, LanguagePreference, Profile } from '@/types'
 
 // Mock lucide-vue-next icons
 vi.mock('lucide-vue-next', () => ({
   Plus: { template: '<span>Plus</span>' },
+  MoreVertical: { template: '<span>MoreVertical</span>' },
+  Upload: { template: '<span>Upload</span>' },
+  Copy: { template: '<span>Copy</span>' },
+  Trash2: { template: '<span>Trash2</span>' },
+  Moon: { template: '<span>Moon</span>' },
+  Sun: { template: '<span>Sun</span>' },
+  Contrast: { template: '<span>Contrast</span>' },
+  Download: { template: '<span>Download</span>' },
 }))
 
 // Mock swapy
@@ -42,19 +50,52 @@ describe('ProfileSidebar', () => {
     ...overrides,
   })
 
-  const mountComponent = (props: { profiles: Profile[]; activeProfileId: string | null }) => {
+  const mountComponent = (props: {
+    profiles: Profile[]
+    activeProfileId: string | null
+    activeProfile?: Profile | null
+    darkModePreference?: DarkModePreference
+    languagePreference?: LanguagePreference
+  }) => {
+    const activeProfile = props.activeProfile
+      ?? props.profiles.find(profile => profile.id === props.activeProfileId)
+      ?? null
+
     return mount(ProfileSidebar, {
-      props,
+      props: {
+        ...props,
+        activeProfile,
+        darkModePreference: props.darkModePreference ?? 'system',
+        languagePreference: props.languagePreference ?? 'auto',
+      },
       global: {
         stubs: {
           Button: {
-            template: '<button @click="$emit(\'click\')"><slot /></button>',
-            props: ['variant', 'size', 'class'],
+            template: '<button :disabled="disabled" @click="$emit(\'click\')"><slot /></button>',
+            props: ['variant', 'size', 'class', 'disabled'],
           },
           Tooltip: { template: '<div><slot /></div>' },
           TooltipContent: { template: '<div><slot /></div>' },
           TooltipProvider: { template: '<div><slot /></div>' },
           TooltipTrigger: { template: '<div><slot /></div>' },
+          DropdownMenu: { template: '<div><slot /></div>' },
+          DropdownMenuTrigger: { template: '<div><slot /></div>' },
+          DropdownMenuContent: { template: '<div><slot /></div>' },
+          DropdownMenuItem: { template: '<div @click="$emit(\'select\')"><slot /></div>' },
+          DropdownMenuSeparator: { template: '<hr />' },
+          AlertDialog: { template: '<div><slot /></div>' },
+          AlertDialogAction: { template: '<button @click="$emit(\'click\')"><slot /></button>' },
+          AlertDialogCancel: { template: '<button @click="$emit(\'click\')"><slot /></button>' },
+          AlertDialogContent: { template: '<div><slot /></div>' },
+          AlertDialogDescription: { template: '<div><slot /></div>' },
+          AlertDialogFooter: { template: '<div><slot /></div>' },
+          AlertDialogHeader: { template: '<div><slot /></div>' },
+          AlertDialogTitle: { template: '<div><slot /></div>' },
+          Select: { template: '<div><slot /></div>' },
+          SelectContent: { template: '<div><slot /></div>' },
+          SelectItem: { template: '<div><slot /></div>' },
+          SelectTrigger: { template: '<div><slot /></div>' },
+          SelectValue: { template: '<div><slot /></div>' },
         },
       },
     })
@@ -171,15 +212,16 @@ describe('ProfileSidebar', () => {
   })
 
   describe('empty state', () => {
-    it('only shows add button when no profiles', () => {
+    it('shows add profile button and no profile items when no profiles', () => {
       const wrapper = mountComponent({
         profiles: [],
         activeProfileId: null,
       })
 
       const buttons = wrapper.findAll('button')
-      expect(buttons.length).toBe(1)
+      expect(buttons.length).toBeGreaterThanOrEqual(1)
       expect(wrapper.text()).toContain('Plus')
+      expect(wrapper.find('[data-swapy-item]').exists()).toBe(false)
     })
   })
 

--- a/src/components/ProfileHeader.vue
+++ b/src/components/ProfileHeader.vue
@@ -1,8 +1,13 @@
 <script setup lang="ts">
-import { ref } from 'vue'
-import type { Profile } from '@/types'
+import { computed, ref, watch } from 'vue'
+import { DEFAULT_PROFILE_COLORS, type Profile } from '@/types'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover'
 import {
   Tooltip,
   TooltipContent,
@@ -13,8 +18,28 @@ import {
   Undo2,
   Redo2,
   Download,
+  Pipette,
 } from 'lucide-vue-next'
 import { t } from '@/i18n'
+import {
+  type HsvColor,
+  clamp,
+  getReadableTextColor,
+  hexToHsv,
+  hsvToHex,
+  parseColorInputToHex,
+  toRgba,
+} from '@/lib/color'
+
+interface EyeDropperResult {
+  sRGBHex: string
+}
+
+interface EyeDropperInstance {
+  open: () => Promise<EyeDropperResult>
+}
+
+type EyeDropperConstructor = new () => EyeDropperInstance
 
 const props = defineProps<{
   profile: Profile | null
@@ -28,11 +53,59 @@ const emit = defineEmits<{
   redo: []
   export: []
   rename: [name: string]
+  updateColor: [color: string]
 }>()
 
 const isEditing = ref(false)
 const editName = ref('')
 const isCanceling = ref(false)
+const colorValueInput = ref('')
+const colorInputInvalid = ref(false)
+
+const profileColor = computed(() => {
+  const normalized = parseColorInputToHex(props.profile?.color ?? '')
+  return normalized ?? '#7c3aed'
+})
+
+const headerTextColor = computed(() => getReadableTextColor(profileColor.value))
+
+const headerStyle = computed(() => ({
+  backgroundColor: props.profile?.color ?? profileColor.value,
+  color: headerTextColor.value,
+  '--profile-header-fg': headerTextColor.value,
+  '--profile-header-fg-muted': toRgba(headerTextColor.value, 0.82),
+  '--profile-header-fg-soft': toRgba(headerTextColor.value, 0.14),
+  '--profile-header-fg-soft-hover': toRgba(headerTextColor.value, 0.24),
+  '--profile-header-fg-border': toRgba(headerTextColor.value, 0.42),
+  '--profile-header-fg-input': toRgba(headerTextColor.value, 0.14),
+  '--profile-header-fg-input-border': toRgba(headerTextColor.value, 0.38),
+}))
+
+const pickerColor = ref<HsvColor>(hexToHsv(profileColor.value))
+
+const sliderTracks = computed(() => {
+  const { h, s, v } = pickerColor.value
+  return {
+    hue: 'linear-gradient(90deg, #ff3b30 0%, #ff9500 17%, #ffcc00 33%, #34c759 50%, #00c7be 67%, #007aff 83%, #af52de 100%)',
+    saturation: `linear-gradient(90deg, ${hsvToHex({ h, s: 0, v })} 0%, ${hsvToHex({ h, s: 100, v })} 100%)`,
+    brightness: `linear-gradient(90deg, #09090b 0%, ${hsvToHex({ h, s, v: 100 })} 100%)`,
+  }
+})
+
+const canUseEyeDropper = computed(() => {
+  if (typeof window === 'undefined') return false
+  return Boolean((window as Window & { EyeDropper?: EyeDropperConstructor }).EyeDropper)
+})
+
+watch(profileColor, (color) => {
+  pickerColor.value = hexToHsv(color)
+  colorValueInput.value = color.toUpperCase()
+  colorInputInvalid.value = false
+}, { immediate: true })
+
+watch(colorValueInput, () => {
+  if (colorInputInvalid.value) colorInputInvalid.value = false
+})
 
 function startEditing() {
   if (!props.profile) return
@@ -43,7 +116,6 @@ function startEditing() {
 
 function finishEditing() {
   if (isCanceling.value) {
-    // Don't save if we're canceling via Escape
     isEditing.value = false
     isCanceling.value = false
     return
@@ -58,41 +130,257 @@ function cancelEditing() {
   isCanceling.value = true
   isEditing.value = false
 }
+
+function emitColor(value: string) {
+  if (!props.profile) return
+  const normalized = parseColorInputToHex(value)
+  if (!normalized) return
+  emit('updateColor', normalized)
+}
+
+function updatePickerColor(updates: Partial<HsvColor>) {
+  pickerColor.value = {
+    ...pickerColor.value,
+    ...updates,
+  }
+  emitColor(hsvToHex(pickerColor.value))
+}
+
+function handleHueInput(event: Event) {
+  const target = event.target as HTMLInputElement | null
+  if (!target) return
+  const value = Number(target.value)
+  if (Number.isNaN(value)) return
+  updatePickerColor({ h: clamp(value, 0, 360) })
+}
+
+function handleSaturationInput(event: Event) {
+  const target = event.target as HTMLInputElement | null
+  if (!target) return
+  const value = Number(target.value)
+  if (Number.isNaN(value)) return
+  updatePickerColor({ s: clamp(value, 0, 100) })
+}
+
+function handleBrightnessInput(event: Event) {
+  const target = event.target as HTMLInputElement | null
+  if (!target) return
+  const value = Number(target.value)
+  if (Number.isNaN(value)) return
+  updatePickerColor({ v: clamp(value, 0, 100) })
+}
+
+function applyColorValueInput() {
+  if (!props.profile) return
+  const normalized = parseColorInputToHex(colorValueInput.value)
+  if (!normalized) {
+    colorInputInvalid.value = true
+    return
+  }
+  colorInputInvalid.value = false
+  emit('updateColor', normalized)
+}
+
+async function pickColorFromScreen() {
+  if (!canUseEyeDropper.value) return
+  try {
+    const EyeDropperClass = (window as Window & { EyeDropper?: EyeDropperConstructor }).EyeDropper
+    if (!EyeDropperClass) return
+    const eyeDropper = new EyeDropperClass()
+    const result = await eyeDropper.open()
+    emitColor(result.sRGBHex)
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') return
+    console.error('EyeDropper failed:', error)
+  }
+}
 </script>
 
 <template>
   <TooltipProvider>
     <div
-      class="flex items-center gap-2 px-3 py-2 text-white"
-      :style="{ backgroundColor: profile?.color || 'hsl(var(--primary))' }"
+      class="profile-header flex items-center gap-2 px-3 py-2"
+      :style="headerStyle"
     >
-      <!-- Profile Number Badge -->
-      <div class="flex items-center justify-center w-7 h-7 rounded-full border-2 border-white/50 text-sm font-medium">
-        {{ profileIndex + 1 }}
-      </div>
+      <Popover>
+        <PopoverTrigger as-child>
+          <button
+            type="button"
+            class="profile-header-badge flex size-7 items-center justify-center rounded-full border-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-0 disabled:cursor-not-allowed disabled:opacity-60"
+            :aria-label="t('tooltip_change_profile_color')"
+            :disabled="!profile"
+            data-testid="profile-color-trigger"
+          >
+            {{ profileIndex + 1 }}
+          </button>
+        </PopoverTrigger>
+        <PopoverContent
+          align="start"
+          class="w-[19rem] rounded-2xl border-border/70 bg-popover/95 p-4 shadow-xl backdrop-blur-sm"
+          data-testid="profile-color-popover"
+        >
+          <div class="grid gap-4">
+            <div class="grid gap-2">
+              <label class="text-[11px] font-semibold uppercase tracking-[0.12em] text-muted-foreground/90">
+                {{ t('profile_color_input_label') }}
+              </label>
+              <div class="grid gap-2 rounded-xl border border-border/70 bg-background/90 p-3 shadow-sm">
+                <div class="flex items-stretch gap-2">
+                  <Input
+                    v-model="colorValueInput"
+                    :placeholder="t('profile_color_input_placeholder')"
+                    class="h-10 rounded-xl bg-background/90 font-medium tracking-wide uppercase"
+                    :class="colorInputInvalid ? 'border-destructive/60 focus-visible:ring-destructive/50' : 'border-border/70'"
+                    data-testid="profile-color-value-input"
+                    @blur="applyColorValueInput"
+                    @keyup.enter="applyColorValueInput"
+                  />
+                  <Tooltip>
+                    <TooltipTrigger as-child>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="icon"
+                        class="size-10 shrink-0 rounded-xl"
+                        :disabled="!canUseEyeDropper"
+                        :aria-label="canUseEyeDropper ? t('profile_color_eyedropper') : t('profile_color_eyedropper_unavailable')"
+                        data-testid="profile-color-eyedropper"
+                        @click="pickColorFromScreen"
+                      >
+                        <Pipette class="h-4 w-4" />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      {{ canUseEyeDropper ? t('profile_color_eyedropper') : t('profile_color_eyedropper_unavailable') }}
+                    </TooltipContent>
+                  </Tooltip>
+                </div>
+                <p
+                  class="text-[11px] tracking-wide"
+                  :class="colorInputInvalid ? 'text-destructive' : 'text-muted-foreground/90'"
+                >
+                  {{ colorInputInvalid ? t('profile_color_input_invalid') : t('profile_color_input_hint') }}
+                </p>
+              </div>
+            </div>
 
-      <!-- Profile Name -->
+            <div class="grid gap-2">
+              <label class="text-[11px] font-semibold uppercase tracking-[0.12em] text-muted-foreground/90">
+                {{ t('profile_color_picker_label') }}
+              </label>
+              <div class="grid gap-2 rounded-xl border border-border/70 bg-background/90 p-3 shadow-sm">
+                <div class="grid gap-1">
+                  <div class="flex items-center justify-between text-[11px] font-semibold uppercase tracking-[0.12em] text-muted-foreground/90">
+                    <span>{{ t('profile_color_hue_label') }}</span>
+                    <span class="tabular-nums">{{ Math.round(pickerColor.h) }}°</span>
+                  </div>
+                  <input
+                    :value="pickerColor.h"
+                    type="range"
+                    min="0"
+                    max="360"
+                    step="1"
+                    class="color-slider"
+                    :style="{ background: sliderTracks.hue }"
+                    data-testid="profile-color-hue-slider"
+                    @input="handleHueInput"
+                  >
+                </div>
+
+                <div class="grid gap-1">
+                  <div class="flex items-center justify-between text-[11px] font-semibold uppercase tracking-[0.12em] text-muted-foreground/90">
+                    <span>{{ t('profile_color_saturation_label') }}</span>
+                    <span class="tabular-nums">{{ Math.round(pickerColor.s) }}%</span>
+                  </div>
+                  <input
+                    :value="pickerColor.s"
+                    type="range"
+                    min="0"
+                    max="100"
+                    step="1"
+                    class="color-slider"
+                    :style="{ background: sliderTracks.saturation }"
+                    data-testid="profile-color-saturation-slider"
+                    @input="handleSaturationInput"
+                  >
+                </div>
+
+                <div class="grid gap-1">
+                  <div class="flex items-center justify-between text-[11px] font-semibold uppercase tracking-[0.12em] text-muted-foreground/90">
+                    <span>{{ t('profile_color_brightness_label') }}</span>
+                    <span class="tabular-nums">{{ Math.round(pickerColor.v) }}%</span>
+                  </div>
+                  <input
+                    :value="pickerColor.v"
+                    type="range"
+                    min="0"
+                    max="100"
+                    step="1"
+                    class="color-slider"
+                    :style="{ background: sliderTracks.brightness }"
+                    data-testid="profile-color-brightness-slider"
+                    @input="handleBrightnessInput"
+                  >
+                </div>
+              </div>
+            </div>
+
+            <div class="grid gap-2">
+              <div class="text-[11px] font-semibold uppercase tracking-[0.12em] text-muted-foreground/90">
+                {{ t('profile_color_presets_label') }}
+              </div>
+              <div class="grid gap-2 rounded-xl border border-border/70 bg-background/90 p-3 shadow-sm">
+                <div class="grid grid-cols-4 justify-items-center gap-2.5">
+                  <button
+                    v-for="color in DEFAULT_PROFILE_COLORS"
+                    :key="color"
+                    type="button"
+                    class="relative size-9 rounded-lg border border-black/5 transition-all duration-150 hover:-translate-y-0.5 hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/70"
+                    :class="color === profileColor
+                      ? 'ring-2 ring-primary/90 ring-offset-2 ring-offset-popover'
+                      : 'hover:shadow-md'"
+                    :style="{
+                      backgroundColor: color,
+                      color: getReadableTextColor(color),
+                    }"
+                    :aria-label="`${t('profile_color_preset')} ${color}`"
+                    @click="emitColor(color)"
+                  >
+                    <span
+                      v-if="color === profileColor"
+                      class="absolute inset-0 grid place-items-center text-[10px] font-bold drop-shadow-sm"
+                    >
+                      ✓
+                    </span>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </PopoverContent>
+      </Popover>
+
       <div v-if="!isEditing" class="flex-1 font-medium cursor-pointer" @dblclick="startEditing">
         {{ profile?.name || t('profile_unnamed') }}
       </div>
       <Input
         v-else
         v-model="editName"
-        class="flex-1 h-8 bg-white/20 border-white/30 text-white placeholder:text-white/50"
+        class="profile-header-name-input flex-1 h-8"
+        data-testid="profile-name-input"
         @blur="finishEditing"
         @keyup.enter="finishEditing"
         @keyup.escape="cancelEditing"
         autofocus
       />
 
-      <!-- Action Buttons -->
       <div class="flex items-center gap-1">
         <Tooltip>
           <TooltipTrigger as-child>
             <Button
               variant="ghost"
               size="icon-sm"
-              class="text-white/80 hover:text-white hover:bg-white/10"
+              class="profile-header-action"
               :disabled="!canUndo"
               :aria-label="t('tooltip_undo')"
               @click="emit('undo')"
@@ -108,7 +396,7 @@ function cancelEditing() {
             <Button
               variant="ghost"
               size="icon-sm"
-              class="text-white/80 hover:text-white hover:bg-white/10"
+              class="profile-header-action"
               :disabled="!canRedo"
               :aria-label="t('tooltip_redo')"
               @click="emit('redo')"
@@ -124,7 +412,7 @@ function cancelEditing() {
             <Button
               variant="ghost"
               size="icon-sm"
-              class="text-white/80 hover:text-white hover:bg-white/10"
+              class="profile-header-action"
               :aria-label="t('tooltip_export_profile')"
               @click="emit('export')"
             >
@@ -137,3 +425,86 @@ function cancelEditing() {
     </div>
   </TooltipProvider>
 </template>
+
+<style scoped>
+.profile-header {
+  --profile-header-fg: #f8fafc;
+  --profile-header-fg-muted: rgba(248, 250, 252, 0.82);
+  --profile-header-fg-soft: rgba(248, 250, 252, 0.14);
+  --profile-header-fg-soft-hover: rgba(248, 250, 252, 0.24);
+  --profile-header-fg-border: rgba(248, 250, 252, 0.42);
+  --profile-header-fg-input: rgba(248, 250, 252, 0.14);
+  --profile-header-fg-input-border: rgba(248, 250, 252, 0.38);
+}
+
+.profile-header-badge {
+  color: var(--profile-header-fg);
+  border-color: var(--profile-header-fg-border);
+  background: var(--profile-header-fg-soft);
+}
+
+.profile-header-badge:hover:not(:disabled) {
+  border-color: var(--profile-header-fg);
+  background: var(--profile-header-fg-soft-hover);
+}
+
+.profile-header-badge:focus-visible {
+  box-shadow: 0 0 0 2px var(--profile-header-fg-soft-hover);
+}
+
+.profile-header-action {
+  color: var(--profile-header-fg-muted);
+}
+
+.profile-header-action:hover:not(:disabled) {
+  color: var(--profile-header-fg);
+  background: var(--profile-header-fg-soft-hover);
+}
+
+.profile-header-name-input {
+  color: var(--profile-header-fg);
+  border-color: var(--profile-header-fg-input-border);
+  background: var(--profile-header-fg-input);
+}
+
+.profile-header-name-input::placeholder {
+  color: var(--profile-header-fg-muted);
+}
+
+.color-slider {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 100%;
+  height: 0.625rem;
+  border-radius: 9999px;
+  border: 1px solid hsl(var(--border) / 0.65);
+  cursor: pointer;
+}
+
+.color-slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 1rem;
+  height: 1rem;
+  border-radius: 9999px;
+  background: #ffffff;
+  border: 0;
+  box-shadow: none;
+}
+
+.color-slider::-moz-range-thumb {
+  width: 1rem;
+  height: 1rem;
+  border-radius: 9999px;
+  background: #ffffff;
+  border: 0;
+  box-shadow: none;
+}
+
+.color-slider::-moz-range-track {
+  height: 0.625rem;
+  border-radius: 9999px;
+  border: none;
+  background: transparent;
+}
+</style>

--- a/src/components/ProfileSidebar.vue
+++ b/src/components/ProfileSidebar.vue
@@ -35,6 +35,7 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { Plus, MoreVertical, Upload, Copy, Trash2, Moon, Sun, Contrast, Download } from 'lucide-vue-next'
+import { getReadableTextColor } from '@/lib/color'
 import { cn } from '@/lib/utils'
 import { t } from '@/i18n'
 
@@ -168,6 +169,13 @@ function getButtonClass(profile: Profile, activeProfileId: string | null): strin
     profile.id === activeProfileId && 'bg-accent'
   )
 }
+
+function getProfileBadgeStyle(color: string): Record<string, string> {
+  return {
+    backgroundColor: color,
+    color: getReadableTextColor(color),
+  }
+}
 </script>
 
 <template>
@@ -201,8 +209,8 @@ function getButtonClass(profile: Profile, activeProfileId: string | null): strin
                     data-swapy-handle
                   >
                     <div
-                      class="grid place-items-center size-6 rounded-full text-[11px] font-semibold leading-none tabular-nums text-white"
-                      :style="{ backgroundColor: item.color }"
+                      class="grid place-items-center size-6 rounded-full text-[11px] font-semibold leading-none tabular-nums"
+                      :style="getProfileBadgeStyle(item.color)"
                     >
                       {{ slottedItems.findIndex(s => s.itemId === itemId) + 1 }}
                     </div>

--- a/src/components/ui/popover/Popover.vue
+++ b/src/components/ui/popover/Popover.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+import type { PopoverRootEmits, PopoverRootProps } from "reka-ui"
+import { PopoverRoot, useForwardPropsEmits } from "reka-ui"
+
+const props = defineProps<PopoverRootProps>()
+const emits = defineEmits<PopoverRootEmits>()
+
+const forwarded = useForwardPropsEmits(props, emits)
+</script>
+
+<template>
+  <PopoverRoot
+    data-slot="popover"
+    v-bind="forwarded"
+  >
+    <slot />
+  </PopoverRoot>
+</template>

--- a/src/components/ui/popover/PopoverContent.vue
+++ b/src/components/ui/popover/PopoverContent.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+import type { PopoverContentEmits, PopoverContentProps } from "reka-ui"
+import type { HTMLAttributes } from "vue"
+import { reactiveOmit } from "@vueuse/core"
+import {
+  PopoverContent,
+  PopoverPortal,
+  useForwardPropsEmits,
+} from "reka-ui"
+import { cn } from "@/lib/utils"
+
+defineOptions({
+  inheritAttrs: false,
+})
+
+const props = withDefaults(
+  defineProps<PopoverContentProps & { class?: HTMLAttributes["class"] }>(),
+  {
+    sideOffset: 8,
+  },
+)
+const emits = defineEmits<PopoverContentEmits>()
+
+const delegatedProps = reactiveOmit(props, "class")
+const forwarded = useForwardPropsEmits(delegatedProps, emits)
+</script>
+
+<template>
+  <PopoverPortal>
+    <PopoverContent
+      data-slot="popover-content"
+      v-bind="{ ...$attrs, ...forwarded }"
+      :class="cn('bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-64 origin-(--reka-popover-content-transform-origin) rounded-md border p-3 shadow-md outline-none', props.class)"
+    >
+      <slot />
+    </PopoverContent>
+  </PopoverPortal>
+</template>

--- a/src/components/ui/popover/PopoverTrigger.vue
+++ b/src/components/ui/popover/PopoverTrigger.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+import type { PopoverTriggerProps } from "reka-ui"
+import { PopoverTrigger, useForwardProps } from "reka-ui"
+
+const props = defineProps<PopoverTriggerProps>()
+const forwardedProps = useForwardProps(props)
+</script>
+
+<template>
+  <PopoverTrigger
+    data-slot="popover-trigger"
+    v-bind="forwardedProps"
+  >
+    <slot />
+  </PopoverTrigger>
+</template>

--- a/src/components/ui/popover/index.ts
+++ b/src/components/ui/popover/index.ts
@@ -1,0 +1,3 @@
+export { default as Popover } from "./Popover.vue"
+export { default as PopoverContent } from "./PopoverContent.vue"
+export { default as PopoverTrigger } from "./PopoverTrigger.vue"

--- a/src/i18n/locales/en/messages.json
+++ b/src/i18n/locales/en/messages.json
@@ -79,6 +79,70 @@
     "message": "Export profile",
     "description": "Tooltip for export profile button"
   },
+  "tooltip_change_profile_color": {
+    "message": "Change profile color",
+    "description": "Tooltip/aria label for opening profile color picker"
+  },
+  "profile_color_label": {
+    "message": "Profile color",
+    "description": "Label shown in the profile color picker popover"
+  },
+  "profile_color_picker_label": {
+    "message": "Color picker",
+    "description": "Label for color control section"
+  },
+  "profile_color_hue_label": {
+    "message": "Hue",
+    "description": "Label for hue slider in profile color picker"
+  },
+  "profile_color_saturation_label": {
+    "message": "Saturation",
+    "description": "Label for saturation slider in profile color picker"
+  },
+  "profile_color_brightness_label": {
+    "message": "Brightness",
+    "description": "Label for brightness slider in profile color picker"
+  },
+  "profile_color_input_label": {
+    "message": "Color input",
+    "description": "Label for free-form profile color input"
+  },
+  "profile_color_input_placeholder": {
+    "message": "#7c3aed or rgb(...) or oklch(...)",
+    "description": "Placeholder text for free-form profile color input"
+  },
+  "profile_color_input_hint": {
+    "message": "Paste hex, rgb(), or oklch() and press Enter.",
+    "description": "Helper text for profile color input field"
+  },
+  "profile_color_input_invalid": {
+    "message": "Invalid color. Use hex, rgb(), or oklch().",
+    "description": "Error text when profile color input cannot be parsed"
+  },
+  "profile_color_eyedropper": {
+    "message": "Pick color from screen",
+    "description": "Tooltip label for eye dropper color picker action"
+  },
+  "profile_color_eyedropper_unavailable": {
+    "message": "Color dropper unavailable in this browser",
+    "description": "Tooltip label when eye dropper API is not available"
+  },
+  "profile_color_hex_label": {
+    "message": "Hex value",
+    "description": "Label for profile color hex input field"
+  },
+  "profile_color_hex_placeholder": {
+    "message": "#7C3AED",
+    "description": "Placeholder text for profile color hex input field"
+  },
+  "profile_color_presets_label": {
+    "message": "Presets",
+    "description": "Label for preset profile colors"
+  },
+  "profile_color_preset": {
+    "message": "Preset color",
+    "description": "Aria label prefix for preset profile color buttons"
+  },
   "menu_export_all_profiles": {
     "message": "Export all profiles",
     "description": "Menu item for exporting all profiles"

--- a/src/i18n/locales/sv/messages.json
+++ b/src/i18n/locales/sv/messages.json
@@ -79,6 +79,70 @@
     "message": "Exportera profil",
     "description": "Tooltip för exportera profil-knapp"
   },
+  "tooltip_change_profile_color": {
+    "message": "Ändra profilfärg",
+    "description": "Tooltip/aria-etikett för att öppna profilens färgväljare"
+  },
+  "profile_color_label": {
+    "message": "Profilfärg",
+    "description": "Etikett i popovern för profilfärg"
+  },
+  "profile_color_picker_label": {
+    "message": "Färgväljare",
+    "description": "Etikett för sektionen med färgkontroller"
+  },
+  "profile_color_hue_label": {
+    "message": "Nyans",
+    "description": "Etikett för nyansreglaget i profilfärgväljaren"
+  },
+  "profile_color_saturation_label": {
+    "message": "Mättnad",
+    "description": "Etikett för mättnadsreglaget i profilfärgväljaren"
+  },
+  "profile_color_brightness_label": {
+    "message": "Ljusstyrka",
+    "description": "Etikett för ljusstyrkereglaget i profilfärgväljaren"
+  },
+  "profile_color_input_label": {
+    "message": "Färginmatning",
+    "description": "Etikett för fri inmatning av profilfärg"
+  },
+  "profile_color_input_placeholder": {
+    "message": "#7c3aed eller rgb(...) eller oklch(...)",
+    "description": "Platshållare för fri inmatning av profilfärg"
+  },
+  "profile_color_input_hint": {
+    "message": "Klistra in hex, rgb() eller oklch() och tryck Enter.",
+    "description": "Hjälptext för fältet med profilfärgens fria inmatning"
+  },
+  "profile_color_input_invalid": {
+    "message": "Ogiltig färg. Använd hex, rgb() eller oklch().",
+    "description": "Feltext när profilfärgen inte kan tolkas"
+  },
+  "profile_color_eyedropper": {
+    "message": "Välj färg från skärmen",
+    "description": "Tooltip-etikett för pipettverktyget"
+  },
+  "profile_color_eyedropper_unavailable": {
+    "message": "Pipettverktyget stöds inte i den här webbläsaren",
+    "description": "Tooltip-etikett när EyeDropper API saknas"
+  },
+  "profile_color_hex_label": {
+    "message": "Hex-värde",
+    "description": "Etikett för fältet med profilfärgens hex-värde"
+  },
+  "profile_color_hex_placeholder": {
+    "message": "#7C3AED",
+    "description": "Platshållare för fältet med profilfärgens hex-värde"
+  },
+  "profile_color_presets_label": {
+    "message": "Förval",
+    "description": "Etikett för förvalda profilfärger"
+  },
+  "profile_color_preset": {
+    "message": "Förinställd färg",
+    "description": "Aria-etikettprefix för förinställda profilfärgsknappar"
+  },
   "menu_export_all_profiles": {
     "message": "Exportera alla profiler",
     "description": "Menyval för att exportera alla profiler"

--- a/src/lib/color.ts
+++ b/src/lib/color.ts
@@ -1,0 +1,220 @@
+import {
+  formatHex,
+  hsv as culoriHsv,
+  oklch as culoriOklch,
+  parse,
+  rgb as culoriRgb,
+  wcagContrast,
+} from 'culori'
+import type { Hsv as CuloriHsv, Oklch as CuloriOklch, Rgb as CuloriRgb } from 'culori'
+
+export interface RgbColor {
+  r: number
+  g: number
+  b: number
+}
+
+export interface HsvColor {
+  h: number
+  s: number
+  v: number
+}
+
+export interface OklchColor {
+  l: number
+  c: number
+  h: number
+}
+
+export function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value))
+}
+
+function toCuloriRgb(color: RgbColor): CuloriRgb {
+  return {
+    mode: 'rgb',
+    r: clamp(color.r, 0, 255) / 255,
+    g: clamp(color.g, 0, 255) / 255,
+    b: clamp(color.b, 0, 255) / 255,
+  }
+}
+
+function fromCuloriRgb(color: CuloriRgb | undefined | null): RgbColor | null {
+  if (!color) return null
+  if (
+    typeof color.r !== 'number'
+    || typeof color.g !== 'number'
+    || typeof color.b !== 'number'
+  ) {
+    return null
+  }
+
+  return {
+    r: Math.round(clamp(color.r, 0, 1) * 255),
+    g: Math.round(clamp(color.g, 0, 1) * 255),
+    b: Math.round(clamp(color.b, 0, 1) * 255),
+  }
+}
+
+function normalizeHex(color: string | undefined): string | null {
+  if (!color) return null
+  return color.toLowerCase()
+}
+
+function parseToCuloriRgb(input: string): CuloriRgb | null {
+  const parsed = parse(input.trim())
+  if (!parsed) return null
+  return culoriRgb(parsed) ?? null
+}
+
+function contrastRatio(colorA: string, colorB: string): number {
+  return wcagContrast(colorA, colorB)
+}
+
+export function hexToRgb(hex: string): RgbColor | null {
+  return parseColorInputToRgb(hex)
+}
+
+export function rgbToHex({ r, g, b }: RgbColor): string {
+  const formatted = normalizeHex(formatHex(toCuloriRgb({ r, g, b })))
+  return formatted ?? '#000000'
+}
+
+export function parseColorInputToRgb(input: string): RgbColor | null {
+  const rgbColor = parseToCuloriRgb(input)
+  return fromCuloriRgb(rgbColor)
+}
+
+export function parseColorInputToHex(input: string): string | null {
+  const parsed = parse(input.trim())
+  if (!parsed) return null
+  return normalizeHex(formatHex(parsed))
+}
+
+export function rgbToHsv({ r, g, b }: RgbColor): HsvColor {
+  const hsvColor = culoriHsv(toCuloriRgb({ r, g, b }))
+  const h = typeof hsvColor?.h === 'number' ? hsvColor.h : 0
+  const s = typeof hsvColor?.s === 'number' ? hsvColor.s * 100 : 0
+  const v = typeof hsvColor?.v === 'number' ? hsvColor.v * 100 : 0
+
+  return {
+    h: clamp(h, 0, 360),
+    s: clamp(s, 0, 100),
+    v: clamp(v, 0, 100),
+  }
+}
+
+export function hsvToRgb({ h, s, v }: HsvColor): RgbColor {
+  const hsvColor: CuloriHsv = {
+    mode: 'hsv',
+    h: Number.isFinite(h) ? h : 0,
+    s: clamp(s, 0, 100) / 100,
+    v: clamp(v, 0, 100) / 100,
+  }
+
+  const rgbColor = culoriRgb(hsvColor)
+  return fromCuloriRgb(rgbColor) ?? { r: 124, g: 58, b: 237 }
+}
+
+export function hexToHsv(hex: string, fallbackHex = '#7c3aed'): HsvColor {
+  const rgbColor = parseColorInputToRgb(hex) ?? parseColorInputToRgb(fallbackHex) ?? { r: 124, g: 58, b: 237 }
+  return rgbToHsv(rgbColor)
+}
+
+export function hsvToHex(hsv: HsvColor): string {
+  return rgbToHex(hsvToRgb(hsv))
+}
+
+export function rgbToOklch({ r, g, b }: RgbColor): OklchColor {
+  const converted = culoriOklch(toCuloriRgb({ r, g, b }))
+  return {
+    l: clamp(typeof converted?.l === 'number' ? converted.l : 0.5, 0, 1),
+    c: clamp(typeof converted?.c === 'number' ? converted.c : 0, 0, 1),
+    h: typeof converted?.h === 'number' ? converted.h : 250,
+  }
+}
+
+export function oklchToRgb({ l, c, h }: OklchColor): RgbColor {
+  const color: CuloriOklch = {
+    mode: 'oklch',
+    l: clamp(l, 0, 1),
+    c: clamp(c, 0, 1),
+    h: Number.isFinite(h) ? h : 250,
+  }
+
+  const rgbColor = culoriRgb(color)
+  return fromCuloriRgb(rgbColor) ?? { r: 124, g: 58, b: 237 }
+}
+
+interface ContrastCandidate {
+  hex: string
+  ratio: number
+}
+
+function findContrastCandidate(
+  backgroundHex: string,
+  backgroundOklch: OklchColor,
+  direction: 'light' | 'dark'
+): ContrastCandidate {
+  const baseHue = Number.isFinite(backgroundOklch.h) ? backgroundOklch.h : 250
+  const hue = direction === 'dark' ? (baseHue + 180) % 360 : baseHue
+  const baseChroma = clamp(backgroundOklch.c * 0.2, 0.008, 0.05)
+
+  const startLightness = direction === 'light' ? 0.7 : 0.38
+  const endLightness = direction === 'light' ? 0.99 : 0.06
+  const steps = 72
+
+  let best: ContrastCandidate | null = null
+  let firstPassing: ContrastCandidate | null = null
+
+  for (let index = 0; index <= steps; index++) {
+    const progress = index / steps
+    const lightness = startLightness + (endLightness - startLightness) * progress
+    const chroma = direction === 'light'
+      ? clamp(baseChroma * (1 - progress * 0.6), 0.004, 0.04)
+      : clamp(baseChroma * (0.85 + progress * 0.3), 0.006, 0.055)
+
+    const candidateHex = rgbToHex(oklchToRgb({
+      l: lightness,
+      c: chroma,
+      h: hue,
+    }))
+    const ratio = contrastRatio(backgroundHex, candidateHex)
+    const candidate = { hex: candidateHex, ratio }
+
+    if (!best || candidate.ratio > best.ratio) best = candidate
+    if (!firstPassing && candidate.ratio >= 4.5) firstPassing = candidate
+  }
+
+  return firstPassing ?? best ?? {
+    hex: direction === 'light' ? '#f8fafc' : '#1f2937',
+    ratio: 1,
+  }
+}
+
+export function getReadableTextColor(backgroundColor: string): string {
+  const backgroundHex = parseColorInputToHex(backgroundColor)
+  if (!backgroundHex) return '#f8fafc'
+
+  // Keep text near-white by default and only switch once contrast genuinely fails.
+  const persistentLightHex = rgbToHex(oklchToRgb({ l: 0.992, c: 0.004, h: 250 }))
+  if (contrastRatio(backgroundHex, persistentLightHex) >= 4.5) {
+    return persistentLightHex
+  }
+
+  const backgroundRgb = parseColorInputToRgb(backgroundHex)
+  if (!backgroundRgb) return '#f8fafc'
+
+  const backgroundOklch = rgbToOklch(backgroundRgb)
+  const darkCandidate = findContrastCandidate(backgroundHex, backgroundOklch, 'dark')
+  if (darkCandidate.ratio >= 4.5) return darkCandidate.hex
+
+  const lightCandidate = findContrastCandidate(backgroundHex, backgroundOklch, 'light')
+  return darkCandidate.ratio >= lightCandidate.ratio ? darkCandidate.hex : lightCandidate.hex
+}
+
+export function toRgba(color: string, alpha: number): string {
+  const rgbColor = parseColorInputToRgb(color)
+  if (!rgbColor) return `rgba(255, 255, 255, ${clamp(alpha, 0, 1)})`
+  return `rgba(${rgbColor.r}, ${rgbColor.g}, ${rgbColor.b}, ${clamp(alpha, 0, 1)})`
+}


### PR DESCRIPTION
## Summary
- make profile badge open a polished popover color editor
- add slider-based picker, eyedropper support, and free-form color input (hex, rgb(), oklch())
- add culori-backed color parsing/conversion utilities and robust contrast-safe text color selection
- ensure sidebar/profile badge labels stay readable on any profile background
- add reusable popover UI wrappers and expand i18n strings for picker controls

## Testing
- bun run test:run src/__tests__/color.test.ts src/__tests__/components/ProfileHeader.test.ts src/__tests__/components/ProfileSidebar.test.ts
- bun run build

Closes #22
