### PR TITLE
ci: add release workflow with auto-generated changelog

### DIFF
--- a/.claude/skills/open-headers-guidelines/SKILL.md
+++ b/.claude/skills/open-headers-guidelines/SKILL.md
@@ -33,7 +33,7 @@ Types:
 
 Examples:
 - `feat: add localhost and path URL filters`
-- `fix: keep action sync without windows API listener`
+- `fix: keep action sync without Windows API listener`
 - `style: dim action icon when native badge count is zero`
 - `chore: bump version to 0.2.0`
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         id: changelog
         run: |
           TAG="${GITHUB_REF#refs/tags/}"
-          PREV_TAG=$(git tag --sort=-v:refname | grep -v "^${TAG}$" | head -n 1)
+          PREV_TAG=$(git tag -l 'v*' --sort=-v:refname | grep -vFx "$TAG" | head -n 1)
 
           if [ -z "$PREV_TAG" ]; then
             RANGE="HEAD"
@@ -78,7 +78,7 @@ jobs:
 
           {
             echo "body<<EOF"
-            echo -e "$CHANGELOG"
+            printf '%b\n' "$CHANGELOG"
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow that triggers on `v*` tag pushes to build the extension, generate a changelog from conventional commits, and create a GitHub Release with a `.zip` artifact
- Add conventional commits guidelines to the project skill so agents follow the format

Closes #26

## Usage
1. Bump version in `package.json` + `manifest.json`, commit
2. `git tag v0.1.0 && git push origin v0.1.0`
3. Workflow builds, tests, zips `dist/`, and creates a release

## Test plan
- [ ] Merge PR, create a test tag, verify the workflow runs
- [ ] Check that the GitHub Release has a changelog and `.zip` attachment
- [ ] Verify `.zip` contains correct `dist/` contents

🤖 Generated with [Claude Code](https://claude.com/claude-code)